### PR TITLE
Initial Flutter flashcard scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Flashcards Mobile App
+
+This repository contains a Flutter-based mobile flashcard application inspired by Anki. The goal is to provide an offline-first, cross-platform experience for studying with spaced repetition.
+
+## Features
+- Create and manage decks of flashcards
+- Review cards using the SM-2 spaced repetition algorithm
+- Offline-first data storage using Hive
+- Simple and clean UI with light and dark themes
+
+## Local Development
+1. Install [Flutter](https://docs.flutter.dev/get-started/install)
+2. Run `flutter pub get` inside the `app` directory
+3. Launch the app with `flutter run`
+
+## Directory Structure
+```
+app/               Flutter project source
+ ├─ lib/
+ │   ├─ models/    Data models
+ │   ├─ services/  Database and logic
+ │   ├─ screens/   UI screens
+ │   └─ widgets/   Reusable widgets
+ ├─ test/          Unit tests
+sample_decks/      Example CSV decks
+```
+
+## Building for iOS/Android
+- Android: `flutter build apk`
+- iOS: `flutter build ios`
+
+## Future Enhancements
+- Cloud sync with Firebase or Supabase
+- AI-powered card generation and mnemonics
+- Audio and image support for cards

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'services/database_service.dart';
+import 'screens/deck_list_screen.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final db = DatabaseService();
+  await db.init();
+  runApp(FlashcardsApp(databaseService: db));
+}
+
+class FlashcardsApp extends StatelessWidget {
+  final DatabaseService databaseService;
+  const FlashcardsApp({super.key, required this.databaseService});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider.value(
+      value: databaseService,
+      child: MaterialApp(
+        title: 'Flashcards',
+        theme: ThemeData.light(),
+        darkTheme: ThemeData.dark(),
+        home: const DeckListScreen(),
+      ),
+    );
+  }
+}

--- a/app/lib/models/deck.dart
+++ b/app/lib/models/deck.dart
@@ -1,0 +1,23 @@
+import 'flashcard.dart';
+
+class Deck {
+  String id;
+  String name;
+  List<Flashcard> cards;
+
+  Deck({required this.id, required this.name, this.cards = const []});
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'cards': cards.map((c) => c.toJson()).toList(),
+      };
+
+  factory Deck.fromJson(Map<String, dynamic> json) => Deck(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        cards: (json['cards'] as List<dynamic>? ?? [])
+            .map((e) => Flashcard.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}

--- a/app/lib/models/flashcard.dart
+++ b/app/lib/models/flashcard.dart
@@ -1,0 +1,37 @@
+import 'review_data.dart';
+
+class Flashcard {
+  String id;
+  String front;
+  String back;
+  List<String> tags;
+  bool mastered;
+  ReviewData review;
+
+  Flashcard({
+    required this.id,
+    required this.front,
+    required this.back,
+    this.tags = const [],
+    this.mastered = false,
+    ReviewData? review,
+  }) : review = review ?? ReviewData();
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'front': front,
+        'back': back,
+        'tags': tags,
+        'mastered': mastered,
+        'review': review.toJson(),
+      };
+
+  factory Flashcard.fromJson(Map<String, dynamic> json) => Flashcard(
+        id: json['id'] as String,
+        front: json['front'] as String,
+        back: json['back'] as String,
+        tags: List<String>.from(json['tags'] ?? []),
+        mastered: json['mastered'] as bool? ?? false,
+        review: ReviewData.fromJson(json['review'] as Map<String, dynamic>),
+      );
+}

--- a/app/lib/models/review_data.dart
+++ b/app/lib/models/review_data.dart
@@ -1,0 +1,27 @@
+class ReviewData {
+  double easeFactor;
+  int interval;
+  int repetitions;
+  DateTime dueDate;
+
+  ReviewData({
+    this.easeFactor = 2.5,
+    this.interval = 0,
+    this.repetitions = 0,
+    DateTime? dueDate,
+  }) : dueDate = dueDate ?? DateTime.now();
+
+  Map<String, dynamic> toJson() => {
+        'easeFactor': easeFactor,
+        'interval': interval,
+        'repetitions': repetitions,
+        'dueDate': dueDate.toIso8601String(),
+      };
+
+  factory ReviewData.fromJson(Map<String, dynamic> json) => ReviewData(
+        easeFactor: (json['easeFactor'] as num).toDouble(),
+        interval: json['interval'] as int,
+        repetitions: json['repetitions'] as int,
+        dueDate: DateTime.parse(json['dueDate'] as String),
+      );
+}

--- a/app/lib/screens/deck_detail_screen.dart
+++ b/app/lib/screens/deck_detail_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/deck.dart';
+import '../models/flashcard.dart';
+import '../services/database_service.dart';
+import 'study_screen.dart';
+
+class DeckDetailScreen extends StatelessWidget {
+  final String deckId;
+  const DeckDetailScreen({super.key, required this.deckId});
+
+  @override
+  Widget build(BuildContext context) {
+    final db = Provider.of<DatabaseService>(context);
+    final deck = db.decks.firstWhere((d) => d.id == deckId);
+    return Scaffold(
+      appBar: AppBar(title: Text(deck.name)),
+      body: ListView.builder(
+        itemCount: deck.cards.length,
+        itemBuilder: (context, index) {
+          final card = deck.cards[index];
+          return ListTile(
+            title: Text(card.front),
+            subtitle: Text(card.back),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => StudyScreen(deckId: deckId),
+            ),
+          );
+        },
+        label: const Text('Study'),
+        icon: const Icon(Icons.play_arrow),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/deck_list_screen.dart
+++ b/app/lib/screens/deck_list_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/deck.dart';
+import '../services/database_service.dart';
+import 'deck_detail_screen.dart';
+
+class DeckListScreen extends StatelessWidget {
+  const DeckListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final db = Provider.of<DatabaseService>(context);
+    final decks = db.decks;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Decks')),
+      body: ListView.builder(
+        itemCount: decks.length,
+        itemBuilder: (context, index) {
+          final deck = decks[index];
+          return ListTile(
+            title: Text(deck.name),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => DeckDetailScreen(deckId: deck.id),
+              ),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final controller = TextEditingController();
+          final name = await showDialog<String>(
+            context: context,
+            builder: (_) => AlertDialog(
+              title: const Text('New Deck'),
+              content: TextField(controller: controller),
+              actions: [
+                TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Cancel')),
+                TextButton(
+                    onPressed: () =>
+                        Navigator.pop(context, controller.text.trim()),
+                    child: const Text('Create')),
+              ],
+            ),
+          );
+          if (name != null && name.isNotEmpty) {
+            final deck = Deck(id: DateTime.now().toIso8601String(), name: name);
+            await db.addDeck(deck);
+          }
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/app/lib/screens/study_screen.dart
+++ b/app/lib/screens/study_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/deck.dart';
+import '../models/flashcard.dart';
+import '../services/database_service.dart';
+import '../widgets/flashcard_view.dart';
+
+class StudyScreen extends StatefulWidget {
+  final String deckId;
+  const StudyScreen({super.key, required this.deckId});
+
+  @override
+  State<StudyScreen> createState() => _StudyScreenState();
+}
+
+class _StudyScreenState extends State<StudyScreen> {
+  Flashcard? currentCard;
+
+  @override
+  void initState() {
+    super.initState();
+    loadNextCard();
+  }
+
+  void loadNextCard() {
+    final db = Provider.of<DatabaseService>(context, listen: false);
+    final deck = db.decks.firstWhere((d) => d.id == widget.deckId);
+    final dueCards = deck.cards
+        .where((c) => c.review.dueDate.isBefore(DateTime.now()))
+        .toList();
+    if (dueCards.isNotEmpty) {
+      currentCard = dueCards.first;
+    } else {
+      currentCard = null;
+    }
+  }
+
+  void gradeCard(int grade) async {
+    final db = Provider.of<DatabaseService>(context, listen: false);
+    final deck = db.decks.firstWhere((d) => d.id == widget.deckId);
+    if (currentCard != null) {
+      await db.reviewCard(deck, currentCard!, grade);
+      loadNextCard();
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Study')),
+      body: currentCard == null
+          ? const Center(child: Text('No cards due'))
+          : Column(
+              children: [
+                Expanded(child: FlashcardView(card: currentCard!)),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    ElevatedButton(
+                        onPressed: () => gradeCard(2),
+                        child: const Text('Again')),
+                    ElevatedButton(
+                        onPressed: () => gradeCard(4),
+                        child: const Text('Good')),
+                    ElevatedButton(
+                        onPressed: () => gradeCard(5),
+                        child: const Text('Easy')),
+                  ],
+                ),
+                const SizedBox(height: 20),
+              ],
+            ),
+    );
+  }
+}

--- a/app/lib/services/database_service.dart
+++ b/app/lib/services/database_service.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../models/deck.dart';
+import '../models/flashcard.dart';
+import 'sm2_service.dart';
+
+class DatabaseService extends ChangeNotifier {
+  static const _boxName = 'flashcardsBox';
+  late Box<String> _box;
+  final sm2 = SM2Service();
+
+  Future<void> init() async {
+    await Hive.initFlutter();
+    _box = await Hive.openBox<String>(_boxName);
+  }
+
+  List<Deck> get decks =>
+      _box.values.map((v) => Deck.fromJson(jsonDecode(v))).toList();
+
+  Future<void> addDeck(Deck deck) async {
+    await _box.put(deck.id, jsonEncode(deck.toJson()));
+    notifyListeners();
+  }
+
+  Future<void> updateDeck(Deck deck) async {
+    await _box.put(deck.id, jsonEncode(deck.toJson()));
+    notifyListeners();
+  }
+
+  Future<void> deleteDeck(String id) async {
+    await _box.delete(id);
+    notifyListeners();
+  }
+
+  Future<void> reviewCard(
+    Deck deck,
+    Flashcard card,
+    int grade,
+  ) async {
+    card.review = sm2.nextReview(card.review, grade);
+    await updateDeck(deck);
+  }
+}

--- a/app/lib/services/sm2_service.dart
+++ b/app/lib/services/sm2_service.dart
@@ -1,0 +1,25 @@
+import '../models/review_data.dart';
+
+class SM2Service {
+  ReviewData nextReview(ReviewData data, int grade) {
+    final q = grade.clamp(0, 5);
+    if (q >= 3) {
+      if (data.repetitions == 0) {
+        data.interval = 1;
+      } else if (data.repetitions == 1) {
+        data.interval = 6;
+      } else {
+        data.interval = (data.interval * data.easeFactor).round();
+      }
+      data.repetitions += 1;
+    } else {
+      data.repetitions = 0;
+      data.interval = 1;
+    }
+
+    data.easeFactor = (data.easeFactor + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02)))
+        .clamp(1.3, double.infinity);
+    data.dueDate = DateTime.now().add(Duration(days: data.interval));
+    return data;
+  }
+}

--- a/app/lib/widgets/flashcard_view.dart
+++ b/app/lib/widgets/flashcard_view.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import '../models/flashcard.dart';
+
+class FlashcardView extends StatefulWidget {
+  final Flashcard card;
+  const FlashcardView({super.key, required this.card});
+
+  @override
+  State<FlashcardView> createState() => _FlashcardViewState();
+}
+
+class _FlashcardViewState extends State<FlashcardView> {
+  bool _showBack = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => setState(() => _showBack = !_showBack),
+      child: Card(
+        margin: const EdgeInsets.all(16),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(32),
+            child: Text(
+              _showBack ? widget.card.back : widget.card.front,
+              style: Theme.of(context).textTheme.headlineMedium,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,0 +1,18 @@
+name: flashcards
+description: A cross-platform flashcard app with offline-first storage.
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  hive: ^2.0.0
+  hive_flutter: ^1.1.0
+  path_provider: ^2.0.0
+  provider: ^6.0.0
+
+flutter:
+  uses-material-design: true

--- a/sample_decks/basic.csv
+++ b/sample_decks/basic.csv
@@ -1,0 +1,4 @@
+Deck Name,Front,Back,Tags
+Spanish Basics,Hola,Hello,greeting
+Spanish Basics,Adiós,Goodbye,greeting
+Spanish Basics,Gracias,Thank you,polite


### PR DESCRIPTION
## Summary
- add Flutter project scaffold and README
- implement models, database service, and SM-2 algorithm
- create basic deck list, deck detail, and study screens
- add flashcard UI widget
- include sample CSV deck

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874c20da4708328b8d16d103e797576